### PR TITLE
Fixed pagination demo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,17 +1,26 @@
+# vscode
 .vscode
 
+# env
 env
 env/*
+venv
+venv/*
+
+# build
 dist
 dist/*
-keys
-keys/*
+build
 transpose_data_test*
 transpose_data_test*/*
 *.egg-info
-
 setup.py
 
+# keys
+keys
+keys/*
+*.env
+
+# python
 __pycache__
 __pycache__/*
-.env

--- a/demo/pagination.py
+++ b/demo/pagination.py
@@ -1,21 +1,10 @@
 from transpose import Transpose
-
 api = Transpose('transpose_api_key')
 
 # get the most recently expired ENS domain
 last_expired = api.ens.records_by_date(type='expiration', order='desc', limit=1)
+print(last_expired[0].ens_name)
 
-print(last_expired.ens_name)
-
-# pagination !
-next_last_expired = api.ens.next()
-
-print(next_last_expired.ens_name) 
-
-last_expired = api.ens.previous()
-
-# Response:
-# 
-# >>> 'jbecker.eth'
-# >>> 'alex101.eth'
-# >>> 'jbecker.eth'
+# pull next recently expired ENS domain
+next_last_expired = api.next()
+print(next_last_expired[0].ens_name) 

--- a/transpose/src/api/block/base.py
+++ b/transpose/src/api/block/base.py
@@ -28,9 +28,6 @@ class Block():
     def next(self) -> List[TransposeModel]:
         return self.super.next()
     
-    def previous(self) -> List[TransposeModel]:
-        return self.super.previous()
-    
     # Get Accounts by Address
     # https://api.transpose.io/v0/block/accounts-by-address
     def accounts_by_address(self, account_addresses: str = None,) -> List[Account]:

--- a/transpose/src/api/ens/base.py
+++ b/transpose/src/api/ens/base.py
@@ -20,9 +20,6 @@ class ENS():
     # https://docs.transpose.io/reference/pagination
     def next(self) -> List[TransposeModel]:
         return self.super.next()
-    
-    def previous(self) -> List[TransposeModel]:
-        return self.super.previous()
         
     # Get ENS Records by Owner
     # https://docs.transpose.io/reference/get_ens-records-by-owner

--- a/transpose/src/api/nft/base.py
+++ b/transpose/src/api/nft/base.py
@@ -35,10 +35,7 @@ class NFT():
     # https://docs.transpose.io/reference/pagination
     def next(self) -> List[TransposeModel]:
         return self.super.next()
-    
-    def previous(self) -> List[TransposeModel]:
-        return self.super.previous()
-    
+        
     # Get Collections by Date Created
     # https://api.transpose.io/v0/nft/collections-by-date-created
     def collections_by_date_created(self,

--- a/transpose/src/api/token/base.py
+++ b/transpose/src/api/token/base.py
@@ -28,9 +28,6 @@ class Token():
     # https://docs.transpose.io/reference/pagination
     def next(self) -> List[TransposeModel]:
         return self.super.next()
-    
-    def previous(self) -> List[TransposeModel]:
-        return self.super.previous()
 
     # Get Tokens by Date Created
     # https://api.transpose.io/v0/token/tokens-by-date-created


### PR DESCRIPTION
Fixed the pagination demo in `demo/pagination.py`. 

It was using an outdated indexing approach, as well use of the `api.previous()` functionality which has been removed.

I also went in a removed all occurrences of `previous()` which is no longer supported.