### PR TITLE
feat: add fuzzy parameter to NFT & Token endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -227,7 +227,7 @@ This returns a list of [ENS Records](https://github.com/TransposeData/transpose-
     "ens_node":"9BFFC8C1EDE1E51E4BAE137FA37A81CC0379FC08123C4AA00A931D0D983956B7",
     "contract_address":"0x57f1887a8BF19b14fC0dF6Fd9B2acc9Af147eA85",
     "token_id":75929000750162030430773866845127925090084516346841580577625168871716954805188,
-    "seq_id":407909,
+    "meta_block_number":407909,
     "owner":"0x2aC92629c4E0E5e4868588f87DC4356606a590b6",
     "resolver":"0x4976fb03C32e5B8cfe2b6cCB31c09Ba78EBaBa41",
     "resolved_address":"0x2aC92629c4E0E5e4868588f87DC4356606a590b6",

--- a/docs/ens.md
+++ b/docs/ens.md
@@ -36,7 +36,7 @@ The **ENS Record Model** contains the full set of information for a single ENS n
 | ens_node               | The unique ENS nodehash which points to the ENS name.                                                   | `string`    |
 | contract_address       | The contract address of the ENS collection.                                                             | `string`    |
 | token_id               | The token ID of the ENS name.                                                                           | `integer`   |
-| seq_id                 | Unique sequential ID of the ENS name used by the Transpose backend.                                     | `integer`   |
+| meta_block_number                 | Unique sequential ID of the ENS name used by the Transpose backend.                                     | `integer`   |
 | owner                  | The owner of the ENS name.                                                                              | `string`    |
 | resolver               | The resolver contract address of the ENS name.                                                          | `string`    |
 | resolved_address       | The address which has this ENS name set to be their primary name.                                       | `string`    |

--- a/docs/nft.md
+++ b/docs/nft.md
@@ -24,8 +24,8 @@ The **NFT API** supports the following groups of endpoints:
 | ---------------------------------------------------------------------------------------- | --------------------------------------------- | ------------------ |
 | `nft.collections_by_date_created(created_after, created_before, standard, order, limit)` | `GET /v0/nft/collections-by-date-created`     | `List[Collection]` |
 | `nft.collections_by_contract_address(contract_addresses)`                                | `GET /v0/nft/collections-by-contract-address` | `List[Collection]` |
-| `nft.collections_by_name(name, limit)`                                                   | `GET /v0/nft/collections-by-name`             | `List[Collection]` |
-| `nft.collections_by_symbol(symbol, limit)`                                               | `GET /v0/nft/collections-by-symbol`           | `List[Collection]` |
+| `nft.collections_by_name(name, limit, fuzzy)`                                                   | `GET /v0/nft/collections-by-name`             | `List[Collection]` |
+| `nft.collections_by_symbol(symbol, limit, fuzzy)`                                               | `GET /v0/nft/collections-by-symbol`           | `List[Collection]` |
 
 ### Collection Model
 <details>
@@ -61,7 +61,7 @@ The **Collection Model** represents a single NFT collection. The **Collection Mo
 | `nft.nfts_by_date_minted(minted_after, minted_before, contract_address, include_burned_nfts, order, limit)` | `GET /v0/nft/nfts-by-date-minted`      | `List[NFT]`          |
 | `nft.nfts_by_contract_address(contract_addresses, include_burned_nfts, limit)`                              | `GET /v0/nft/nfts-by-contract-address` | `List[NFT]`          |
 | `nft.nfts_by_token_id(contract_addresses, token_ids, include_burned_nfts, limit)`                           | `GET /v0/nft/nfts-by-token-id`         | `List[NFT]`          |
-| `nft.nfts_by_name(name, include_burned_nfts, limit)`                                                        | `GET /v0/nft/nfts-by-name`             | `List[NFT]`          |
+| `nft.nfts_by_name(name, include_burned_nfts, limit, fuzzy)`                                                        | `GET /v0/nft/nfts-by-name`             | `List[NFT]`          |
 | `nft.nfts_by_owner(owner_address, contract_address, limit)`                                                 | `GET /v0/nft/nfts-by-owner`            | `List[NFTWithOwner]` |
 | `nft.nfts_by_approved_account(approved_address, contract_address, limit)`                                   | `GET /v0/nft/nfts-by-approved-account` | `List[NFT]`          |
 

--- a/docs/token.md
+++ b/docs/token.md
@@ -22,8 +22,8 @@ The **Token API** supports the following groups of endpoints:
 | ----------------------------------------------------------------------------------------------------------- | ------------------------------------------ | ---------------------- |
 | `token.tokens_by_date_created(created_after, created_before, standard, order, limit)`                       | `GET /v0/token/tokens-by-date-created`     | `List[Token]`          |
 | `token.tokens_by_contract_address(contract_address, created_after, created_before, standard, order, limit)` | `GET /v0/token/tokens-by-contract-address` | `List[Token]`          |
-| `token.tokens_by_name(name, limit)`                                                                         | `GET /v0/token/tokens-by-name`             | `List[Token]`          |
-| `token.tokens_by_symbol(symbol, limit)`                                                                     | `GET /v0/token/tokens-by-symbol`           | `List[Token]`          |
+| `token.tokens_by_name(name, limit, fuzzy)`                                                                         | `GET /v0/token/tokens-by-name`             | `List[Token]`          |
+| `token.tokens_by_symbol(symbol, limit, fuzzy)`                                                                     | `GET /v0/token/tokens-by-symbol`           | `List[Token]`          |
 | `token.tokens_by_owner(owner_address, contract_address, limit)`                                             | `GET /v0/token/tokens-by-owner`            | `List[TokenWithOwner]` |
 
 ### Token Model

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ setup(
     
     # version compliant with PEP440
     # https://peps.python.org/pep-0440/
-    version='1.3.1',
+    version='1.3.2',
     
     # project meta
     long_description = long_description,

--- a/tests/test_nft_collections_by_name.py
+++ b/tests/test_nft_collections_by_name.py
@@ -4,7 +4,7 @@ def test_basic():
     try:
         api = Transpose(api_key)
 
-        collections = api.nft.collections_by_name(name='ape')
+        collections = api.nft.collections_by_name(name='ape', fuzzy=True)
         
         assert len(collections) >= 1
         assert all(collection.contract_address != None for collection in collections)
@@ -16,7 +16,7 @@ def test_cursor():
     try:
         api = Transpose(api_key)
 
-        collections = api.nft.collections_by_name(name='ape')
+        collections = api.nft.collections_by_name(name='ape', fuzzy=True)
         
         assert len(collections) >= 10
         assert all(collection.contract_address != None for collection in collections)

--- a/tests/test_nft_collections_by_symbol.py
+++ b/tests/test_nft_collections_by_symbol.py
@@ -4,7 +4,7 @@ def test_basic():
     try:
         api = Transpose(api_key)
 
-        collections = api.nft.collections_by_symbol(symbol='ayc')
+        collections = api.nft.collections_by_symbol(symbol='ayc', fuzzy=True)
         
         assert len(collections) >= 1
         assert all(collection.contract_address != None for collection in collections)
@@ -16,7 +16,7 @@ def test_cursor():
     try:
         api = Transpose(api_key)
 
-        collections = api.nft.collections_by_symbol(symbol='ayc')
+        collections = api.nft.collections_by_symbol(symbol='ayc', fuzzy=True)
         
         assert len(collections) >= 10
         assert all(collection.contract_address != None for collection in collections)

--- a/tests/test_nft_nfts_by_name.py
+++ b/tests/test_nft_nfts_by_name.py
@@ -4,7 +4,7 @@ def test_basic():
     try:
         api = Transpose(api_key)
 
-        tokens = api.nft.nfts_by_name(name='ape')
+        tokens = api.nft.nfts_by_name(name='ape', fuzzy=True)
         
         assert len(tokens) >= 1
         assert all(token.contract_address != None for token in tokens)
@@ -16,7 +16,7 @@ def test_cursor():
     try:
         api = Transpose(api_key)
 
-        tokens = api.nft.nfts_by_name(name='ape')
+        tokens = api.nft.nfts_by_name(name='ape', fuzzy=True)
         
         assert len(tokens) >= 10
         assert all(token.contract_address != None for token in tokens)

--- a/tests/test_token_tokens_by_name.py
+++ b/tests/test_token_tokens_by_name.py
@@ -4,7 +4,7 @@ def test_basic():
     try:
         api = Transpose(api_key)
 
-        collections = api.token.tokens_by_name(name='ape')
+        collections = api.token.tokens_by_name(name='ape', fuzzy=True)
         
         assert len(collections) >= 1
         assert all(collection.contract_address != None for collection in collections)
@@ -16,7 +16,7 @@ def test_cursor():
     try:
         api = Transpose(api_key)
 
-        collections = api.token.tokens_by_name(name='ape')
+        collections = api.token.tokens_by_name(name='ape', fuzzy=True)
         
         assert len(collections) >= 10
         assert all(collection.contract_address != None for collection in collections)

--- a/tests/test_token_tokens_by_symbol.py
+++ b/tests/test_token_tokens_by_symbol.py
@@ -4,7 +4,7 @@ def test_basic():
     try:
         api = Transpose(api_key)
 
-        collections = api.token.tokens_by_symbol(symbol='usd')
+        collections = api.token.tokens_by_symbol(symbol='usd', fuzzy=True)
         
         assert len(collections) >= 1
         assert all(collection.contract_address != None for collection in collections)
@@ -16,7 +16,7 @@ def test_cursor():
     try:
         api = Transpose(api_key)
 
-        collections = api.token.tokens_by_symbol(symbol='usd')
+        collections = api.token.tokens_by_symbol(symbol='usd', fuzzy=True)
         
         assert len(collections) >= 10
         assert all(collection.contract_address != None for collection in collections)

--- a/transpose/src/api/nft/_collections_by_name.py
+++ b/transpose/src/api/nft/_collections_by_name.py
@@ -1,8 +1,9 @@
 from ..constants import NFT_API_ENDPOINTS
 
 def _collections_by_name(name: str=None,
-                         limit: int=10) -> str:
+                         limit: int=10,
+                         fuzzy: bool=False) -> str:
     
-    base_url = '{}?substring={}&limit={}'.format(NFT_API_ENDPOINTS['collections_by_name'], name, limit)
+    base_url = '{}?substring={}&limit={}&fuzzy={}'.format(NFT_API_ENDPOINTS['collections_by_name'], name, limit, fuzzy)
     
     return base_url

--- a/transpose/src/api/nft/_collections_by_symbol.py
+++ b/transpose/src/api/nft/_collections_by_symbol.py
@@ -1,8 +1,9 @@
 from ..constants import NFT_API_ENDPOINTS
 
 def _collections_by_symbol(symbol: str=None,
-                           limit: int=10) -> str:
+                           limit: int=10,
+                           fuzzy: bool=False) -> str:
     
-    base_url = '{}?substring={}&limit={}'.format(NFT_API_ENDPOINTS['collections_by_symbol'], symbol, limit)
+    base_url = '{}?substring={}&limit={}&fuzzy={}'.format(NFT_API_ENDPOINTS['collections_by_symbol'], symbol, limit, fuzzy)
     
     return base_url

--- a/transpose/src/api/nft/_nfts_by_name.py
+++ b/transpose/src/api/nft/_nfts_by_name.py
@@ -2,8 +2,9 @@ from ..constants import NFT_API_ENDPOINTS
 
 def _nfts_by_name(name: str=None,
                   include_burned_nfts: bool=False,
-                  limit: int=10) -> str:
+                  limit: int=10,
+                  fuzzy: bool=False) -> str:
     
-    base_url = '{}?substring={}&include_burned_nfts={}&limit={}'.format(NFT_API_ENDPOINTS['nfts_by_name'], name, include_burned_nfts, limit)
+    base_url = '{}?substring={}&include_burned_nfts={}&limit={}&fuzzy={}'.format(NFT_API_ENDPOINTS['nfts_by_name'], name, include_burned_nfts, limit, fuzzy)
     
     return base_url

--- a/transpose/src/api/nft/base.py
+++ b/transpose/src/api/nft/base.py
@@ -60,15 +60,17 @@ class NFT():
     # https://api.transpose.io/v0/nft/collections-by-name
     def collections_by_name(self, 
                             name: str=None,
-                            limit: int=10) -> List[Collection]:
-        return self.super.perform_authorized_request(Collection, _collections_by_name(name, limit))
+                            limit: int=10,
+                            fuzzy: bool=False) -> List[Collection]:
+        return self.super.perform_authorized_request(Collection, _collections_by_name(name, limit, fuzzy))
     
     # Get Collections by Synbol
     # https://api.transpose.io/v0/nft/collections-by-symbol
     def collections_by_symbol(self,
                               symbol: str=None,
-                              limit: int=10) -> List[Collection]:
-        return self.super.perform_authorized_request(Collection, _collections_by_symbol(symbol, limit))
+                              limit: int=10,
+                              fuzzy: bool=False) -> List[Collection]:
+        return self.super.perform_authorized_request(Collection, _collections_by_symbol(symbol, limit, fuzzy))
     
     # Get NFTs by Date Minted
     # https://api.transpose.io/v0/nft/nfts-by-date-minted
@@ -102,8 +104,9 @@ class NFT():
     def nfts_by_name(self,
                      name: str = None, 
                      include_burned_nfts: bool = False,
-                     limit: int = 10) -> List[NFTModel]:
-        return self.super.perform_authorized_request(NFTModel, _nfts_by_name(name, include_burned_nfts, limit))
+                     limit: int = 10,
+                     fuzzy: bool=False) -> List[NFTModel]:
+        return self.super.perform_authorized_request(NFTModel, _nfts_by_name(name, include_burned_nfts, limit, fuzzy))
     
     # Get NFTs by Owner
     # https://api.transpose.io/v0/nft/nfts-by-owner

--- a/transpose/src/api/token/_tokens_by_name.py
+++ b/transpose/src/api/token/_tokens_by_name.py
@@ -1,8 +1,9 @@
 from ..constants import TOKEN_API_ENDPOINTS
 
 def _tokens_by_name(name: str=None,
-                    limit: int=10) -> str:
+                    limit: int=10,
+                    fuzzy: bool=False) -> str:
     
-    base_url = '{}?substring={}&limit={}'.format(TOKEN_API_ENDPOINTS['tokens_by_name'], name, limit)
+    base_url = '{}?substring={}&limit={}'.format(TOKEN_API_ENDPOINTS['tokens_by_name'], name, limit, fuzzy)
     
     return base_url

--- a/transpose/src/api/token/_tokens_by_symbol.py
+++ b/transpose/src/api/token/_tokens_by_symbol.py
@@ -1,8 +1,9 @@
 from ..constants import TOKEN_API_ENDPOINTS
 
 def _tokens_by_symbol(symbol: str=None,
-                      limit: int=10) -> str:
+                      limit: int=10,
+                      fuzzy: bool=False) -> str:
     
-    base_url = '{}?substring={}&limit={}'.format(TOKEN_API_ENDPOINTS['tokens_by_symbol'], symbol, limit)
+    base_url = '{}?substring={}&limit={}'.format(TOKEN_API_ENDPOINTS['tokens_by_symbol'], symbol, limit, fuzzy)
     
     return base_url

--- a/transpose/src/api/token/base.py
+++ b/transpose/src/api/token/base.py
@@ -53,15 +53,17 @@ class Token():
     # https://api.transpose.io/v0/token/tokens-by-name
     def tokens_by_name(self,
                        name: str=None,
-                       limit: int=10) -> List[TokenModel]:
-        return self.super.perform_authorized_request(TokenModel, _tokens_by_name(name, limit))
+                       limit: int=10,
+                       fuzzy: bool=False) -> List[TokenModel]:
+        return self.super.perform_authorized_request(TokenModel, _tokens_by_name(name, limit, fuzzy))
     
     # Get Tokens by Symbol
     # https://api.transpose.io/v0/token/tokens-by-symbol
     def tokens_by_symbol(self,
                          symbol: str=None,
-                         limit: int=10) -> List[TokenModel]:
-        return self.super.perform_authorized_request(TokenModel, _tokens_by_symbol(symbol, limit))
+                         limit: int=10,
+                         fuzzy: bool=False) -> List[TokenModel]:
+        return self.super.perform_authorized_request(TokenModel, _tokens_by_symbol(symbol, limit, fuzzy))
     
     # Get Tokens by Owner
     # https://api.transpose.io/v0/token/tokens-by-owner

--- a/transpose/src/util/models.py
+++ b/transpose/src/util/models.py
@@ -161,7 +161,7 @@ class ENSRecord(TransposeModel):
         self.ens_node: str = None
         self.contract_address: str = None
         self.token_id: int = None
-        self.seq_id: int = None
+        self.meta_block_number: int = None
         self.owner: str = None
         self.resolver: str = None
         self.resolved_address: str = None


### PR DESCRIPTION
- Add `fuzzy` parameter on [`token.tokens_by_name`, `token.tokens_by_symbol`, `nft.collections_by_name`, `nft.collections_by_symbol`, and `nft.nfts_by_name`].
  -  This parameter allows you to toggle between an exact string search or fuzzy search. _(default: `false`)_
- Update `seq_id` on ENS endpoints to `meta_block_number`