### PR TITLE
fix: call block_number property of BlockObject

### DIFF
--- a/demo/gas.py
+++ b/demo/gas.py
@@ -6,4 +6,4 @@ api = Transpose('API_KEY')
 
 blocks = api.block.blocks_by_number(order='desc', limit=500)
 fig, ax = plt.subplots()
-ax.plot([x.number for x in blocks], [x.gas_used for x in blocks])
+ax.plot([x.block_number for x in blocks], [x.gas_used for x in blocks])


### PR DESCRIPTION
SDK example gives error when trying to call the "number" property, which no longer exists